### PR TITLE
fix(peerDependencies): Expand the range of allowable versions of nestjs/swagger.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@nestjs/common": "10 - 11",
     "@nestjs/core": "10 - 11",
     "@nestjs/platform-express": "10 - 11",
-    "@nestjs/swagger": "^8.0.0",
+    "@nestjs/swagger": "8 - 11",
     "swagger-ui-express": "^5.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Allow multiple swagger versions.